### PR TITLE
debug logs DOH response headers

### DIFF
--- a/pkg/resolvers/doh.go
+++ b/pkg/resolvers/doh.go
@@ -80,6 +80,14 @@ func (r *DOHResolver) Lookup(question dns.Question) (Response, error) {
 			return rsp, fmt.Errorf("error from nameserver %s", resp.Status)
 		}
 		rtt := time.Since(now)
+		// if debug, extract the response headers
+		if r.resolverOptions.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			for header, value := range resp.Header {
+				r.resolverOptions.Logger.WithFields(logrus.Fields{
+					header: value,
+				}).Debug("DOH response header")
+			}
+		}
 		// extract the binary response in DNS Message.
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
I was interested in the response headers sent from DOH resolvers, and made a simple mod.  I thought I'd share in case this might be of interest.
e.g. 
`doggo --debug --time @https://9.9.9.9/dns-query example.com`

```
time="2021-08-10T22:03:16+01:00" level=debug msg="initiating DOH resolver"
time="2021-08-10T22:03:16+01:00" level=debug msg="Starting doggo 🐶"
time="2021-08-10T22:03:16+01:00" level=debug msg="Attempting to resolve" domain=example.com. nameserver="https://9.9.9.9/dns-query" ndots=0
time="2021-08-10T22:03:16+01:00" level=debug msg="DOH response header" Content-Type="[application/dns-message]"
time="2021-08-10T22:03:16+01:00" level=debug msg="DOH response header" Cache-Control="[max-age=43002]"
time="2021-08-10T22:03:16+01:00" level=debug msg="DOH response header" Content-Length="[45]"
time="2021-08-10T22:03:16+01:00" level=debug msg="DOH response header" Server="[h2o/dnsdist]"
time="2021-08-10T22:03:16+01:00" level=debug msg="DOH response header" Date="[Tue, 10 Aug 2021 21:03:16 GMT]"
NAME        	TYPE	CLASS	TTL   	ADDRESS      	NAMESERVER               	TIME TAKEN 
example.com.	A   	IN   	43002s	93.184.216.34	https://9.9.9.9/dns-query	112ms  
```

