### PR TITLE
docs: use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ yay -S doggo-bin
 You need to have `go` installed in your system.
 
 ```bash
-$ go get github.com/mr-karan/doggo/cmd/doggo
+$ go install github.com/mr-karan/doggo/cmd/doggo@latest
 ```
 
 The binary will be available at `$GOPATH/bin/doggo`.


### PR DESCRIPTION
Hi, Karan.
When I ran `go get github.com/mr-karan/doggo/cmd/doggo` with Go1.17.1, I got this:
```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```
> https://golang.org/doc/go-get-install-deprecation
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. > Specifically, go get will always act as if the -d flag were enabled.

It means that `go get github.com/mr-karan/doggo/cmd/doggo` is deprecated and won't work for Go 1.18
This pull request is to change `go get` into `go install`