### PR TITLE
fix: Correctly print colored text on Windows

### DIFF
--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -100,7 +100,7 @@ func renderCustomHelp() {
 		// should ideally never happen.
 		panic(err)
 	}
-	err = tmpl.Execute(os.Stdout, helpTmplVars)
+	err = tmpl.Execute(color.Output, helpTmplVars)
 	if err != nil {
 		// should ideally never happen.
 		panic(err)

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/miekg/dns"
@@ -45,7 +44,7 @@ func (app *App) outputTerminal(rsp []resolvers.Response) {
 	}
 
 	// Conditional Time column.
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(color.Output)
 	header := []string{"Name", "Type", "Class", "TTL", "Address", "Nameserver"}
 	if app.QueryFlags.DisplayTimeTaken {
 		header = append(header, "Time Taken")


### PR DESCRIPTION
This commit will fix #40.

Replacing os.Stdout with color.Output will fix the problem on Windows's console.

Internally, `color.Output` is same as `colorable.NewColorableStdout()`, according to https://github.com/fatih/color/blob/acd5f3bb28257af7d3c4817ab6842e39bd0fcf34/color.go#L25-L27

see also: https://godocs.io/github.com/mattn/go-colorable#NewColorableStdout