### PR TITLE
Add install alternative via Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ $ brew install doggo
 yay -S doggo-bin
 ```
 
+#### Scoop
+
+Install via [Scoop](https://scoop.sh/)
+
+```bash
+scoop install doggo
+```
+
 ### From Source
 
 You need to have `go` installed in your system.


### PR DESCRIPTION
Add installation option via Scoop for Windows (added as ScoopInstaller/Main#4093).
Fixes #36.