### PR TITLE
Support literal IPv6 nameservers

### DIFF
--- a/internal/app/nameservers.go
+++ b/internal/app/nameservers.go
@@ -61,7 +61,11 @@ func initNameserver(n string) (models.Nameserver, error) {
 	}
 	u, err := url.Parse(n)
 	if err != nil {
-		return ns, err
+		ip := net.ParseIP(n)
+		if ip == nil {
+			return ns, err
+		}
+		return ns, nil
 	}
 	switch u.Scheme {
 	case "sdns":


### PR DESCRIPTION
This effectively means that `doggo @2001:DB8::53 example.org` works just like we know it from `dig(1)`. This already works for IPv4 because `url.Parse` accepts a literal IPv4 address, but not a literal IPv6 address (due to parsing ambiguities with strings that look like an IPv4 address I guess).

This is implemented by checking if the nameserver argument is a valid IP if the URL validation failed. If that's the case, `ns` is returned directly with the `[2001:DB8::53]:53` as address (from `net.JoinHostPort` with the default DNS port) and UDP as protocol (also the default if not specified).