### PR TITLE
Add support for dns trace

### DIFF
--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -45,6 +45,7 @@ var appHelpTextTemplate = `{{ "NAME" | color "" "heading" }}:
   {{"-n, --nameserver=ADDR" | color "yellow" ""}}       Address of a specific nameserver to send queries to ({{"9.9.9.9, 8.8.8.8" | color "cyan" ""}} etc).
   {{"-c, --class=CLASS" | color "yellow" ""}}           Network class of the DNS record ({{"IN, CH, HS" | color "cyan" ""}} etc).
   {{"-x, --reverse" | color "yellow" ""}}               Performs a DNS Lookup for an IPv4 or IPv6 address. Sets the query type and class to PTR and IN respectively.
+  {{"--trace" | color "yellow" ""}}                     Perform a dns trace operation against the given domain name
 
 {{ "Resolver Options" | color "" "heading" }}:
   {{"--strategy=STRATEGY" | color "yellow" ""}}          Specify strategy to query nameserver listed in etc/resolv.conf. ({{"all, random, first" | color "cyan" ""}}).

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/pprof v0.0.0-20221219190121-3cb0bae90811 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/marten-seemann/qtls-go1-18 v0.1.4 // indirect
 	github.com/marten-seemann/qtls-go1-19 v0.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -34,6 +36,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/onsi/ginkgo/v2 v2.6.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
 	golang.org/x/exp v0.0.0-20221230185412-738e83a70c30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -126,6 +127,8 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
@@ -237,6 +240,7 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -115,14 +115,18 @@ func (app *App) outputTerminal(rsp []resolvers.Response) {
 			table.Append(output)
 		}
 		for _, auth := range r.Authorities {
-			var typOut string
+			var typOut, addr string
 			switch typ := auth.Type; typ {
 			case "SOA":
 				typOut = red(auth.Type)
+				addr = auth.MName
+			case "NS":
+				typOut = cyan(auth.Type)
+				addr = auth.Address
 			default:
 				typOut = blue(auth.Type)
 			}
-			output := []string{green(auth.Name), typOut, auth.Class, auth.TTL, auth.MName, auth.Nameserver}
+			output := []string{green(auth.Name), typOut, auth.Class, auth.TTL, addr, auth.Nameserver}
 			// Print how long it took
 			if app.QueryFlags.DisplayTimeTaken {
 				output = append(output, auth.RTT)

--- a/internal/app/resolve.go
+++ b/internal/app/resolve.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/miekg/dns"
+	"github.com/mr-karan/doggo/pkg/resolvers"
+	"github.com/pkg/errors"
+	"net"
+	"time"
+)
+
+// Resolve resolves the given DNS queries using the configured resolvers
+func (app *App) Resolve() (_ []resolvers.Response, err error) {
+	app.LoadFallbacks()
+	app.PrepareQuestions()
+
+	var responses []resolvers.Response
+
+	for _, q := range app.Questions {
+		for _, rslv := range app.Resolvers {
+			if resp, lookupError := rslv.Lookup(q); lookupError != nil {
+				err = multierror.Append(err, lookupError)
+			} else {
+				responses = append(responses, resp)
+			}
+		}
+	}
+
+	return responses, err
+}
+
+// Trace traces the resolution path for a dns query.
+//
+// It resolves the query from the root nameservers downwards and return the results from each query step.
+// It will only use the default or explicitly specified nameserver for the initial discovery of the root nameservers.
+// Thereafter, it makes its own queries following the delegation referrals it receives.
+//
+// adapted from: https://superuser.com/a/715656
+func (app *App) Trace() (result []resolvers.Response, err error) {
+	// pick the first resolver configured
+	var rslv = app.Resolvers[0]
+	app.Logger.Debugf("using %v resolver", rslv)
+
+	var ques = dns.Question{Name: app.QueryFlags.QNames[0], Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	var ans resolvers.Response
+
+	// first, we ask the configured nameserver for NS record for "." (root)
+	if ans, err = rslv.Lookup(dns.Question{Name: ".", Qtype: dns.TypeNS, Qclass: dns.ClassINET}); err != nil {
+		return nil, errors.Wrapf(err, "failed to lookup NS record for root")
+	}
+	result = append(result, ans)
+
+	var nameservers []string
+	for _, auth := range ans.Answers {
+		if auth.Type == dns.TypeToString[dns.TypeNS] {
+			nameservers = append(nameservers, auth.Address)
+		}
+	}
+
+	var classicResolverOpts = resolvers.ClassicResolverOpts{UseTLS: false, UseTCP: false}
+	var resolverOpts = resolvers.Options{
+		Nameservers:        app.Nameservers,
+		UseIPv4:            app.QueryFlags.UseIPv4,
+		UseIPv6:            app.QueryFlags.UseIPv6,
+		SearchList:         app.ResolverOpts.SearchList,
+		Ndots:              app.ResolverOpts.Ndots,
+		Timeout:            app.QueryFlags.Timeout * time.Second,
+		Logger:             app.Logger,
+		Strategy:           app.QueryFlags.Strategy,
+		InsecureSkipVerify: app.QueryFlags.InsecureSkipVerify,
+		TLSHostname:        app.QueryFlags.TLSHostname,
+	}
+
+	// TODO: randomize picking of nameservers (or query all nameservers?)
+	var nameserver = net.JoinHostPort(nameservers[0], "53")
+	for {
+		rslv, _ = resolvers.NewClassicResolver(nameserver, classicResolverOpts, resolverOpts) // safe to suppress here
+		if ans, err = rslv.Lookup(ques); err != nil {
+			return nil, errors.Wrapf(err, "failed to trace %q", ques.Name)
+		}
+		result = append(result, ans)
+
+		var prev = nameserver
+		// pick the first authority response of type NS
+		for _, auth := range ans.Authorities {
+			if auth.Type == dns.TypeToString[dns.TypeNS] {
+				nameserver = net.JoinHostPort(auth.Address, "53")
+				break
+			}
+		}
+
+		// in case there is no change in the nameserver, does that mean we have reached end of delegation chain?
+		// currently, we are assuming that and using it as a terminating condition
+		if len(ans.Answers) > 0 || nameserver == prev {
+			break
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/resolvers/resolver.go
+++ b/pkg/resolvers/resolver.go
@@ -62,7 +62,8 @@ type Authority struct {
 	Type       string `json:"type"`
 	Class      string `json:"class"`
 	TTL        string `json:"ttl"`
-	MName      string `json:"mname"`
+	Address    string `json:"address,omitempty"`
+	MName      string `json:"mname,omitempty"`
 	Status     string `json:"status"`
 	RTT        string `json:"rtt"`
 	Nameserver string `json:"nameserver"`


### PR DESCRIPTION
This PR adds some base level support for dns tracing, as outlined in #52 and implemented by [`dig +trace`](https://linux.die.net/man/1/dig)