### PR TITLE
added tls client configuration for doh and doq

### DIFF
--- a/pkg/resolvers/doh.go
+++ b/pkg/resolvers/doh.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -30,8 +31,14 @@ func NewDOHResolver(server string, resolverOpts Options) (Resolver, error) {
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("missing https in %s", server)
 	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config {
+		ServerName:         resolverOpts.TLSHostname,
+		InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+	}
 	httpClient := &http.Client{
 		Timeout: resolverOpts.Timeout,
+		Transport: transport,
 	}
 	return &DOHResolver{
 		client:          httpClient,

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -26,7 +26,9 @@ type DOQResolver struct {
 func NewDOQResolver(server string, resolverOpts Options) (Resolver, error) {
 	return &DOQResolver{
 		tls: &tls.Config{
-			NextProtos: []string{"doq"},
+			NextProtos: 		[]string{"doq"},
+			ServerName: 		resolverOpts.TLSHostname,
+			InsecureSkipVerify: 	resolverOpts.InsecureSkipVerify,
 		},
 		server:          server,
 		resolverOptions: resolverOpts,


### PR DESCRIPTION
The "classic" resolver had tls configuration set from command line, added the same to DoH and DoQ. 