### PR TITLE
feat: add support for common query types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./docs/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/docs/package-lock.json') }}

--- a/cmd/doggo/cli.go
+++ b/cmd/doggo/cli.go
@@ -120,6 +120,8 @@ func setupFlags() *flag.FlagSet {
 	f.String("tls-hostname", "", "Hostname for certificate verification")
 	f.Bool("skip-hostname-verification", false, "Skip TLS Hostname Verification")
 
+	f.Bool("any", false, "Query all supported DNS record types")
+
 	f.BoolP("json", "J", false, "Set the output format as JSON")
 	f.Bool("short", false, "Short output format")
 	f.Bool("time", false, "Display how long the response took")

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -99,6 +99,7 @@ func renderCustomHelp() {
 			{"-n, --nameserver=ADDR", "Address of a specific nameserver to send queries to (9.9.9.9, 8.8.8.8 etc)."},
 			{"-c, --class=CLASS", "Network class of the DNS record (IN, CH, HS etc)."},
 			{"-x, --reverse", "Performs a DNS Lookup for an IPv4 or IPv6 address. Sets the query type and class to PTR and IN respectively."},
+			{"--any", "Query all supported DNS record types (A, AAAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, CAA)."},
 		},
 		"ResolverOptions": []Option{
 			{"--strategy=STRATEGY", "Specify strategy to query nameserver listed in etc/resolv.conf. (all, random, first)."},

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -19,7 +19,7 @@ var appHelpTextTemplate = `{{ "NAME" | color "" "heading" }}:
 
 {{ "EXAMPLES" | color "" "heading" }}:
   {{- range $example := .Examples }}
-  {{ $.Name | color "green" "bold" }} {{ $example.Command | color "cyan" "" }}{{ printf "%-4s" "" }}{{ $example.Description }}
+  {{ $.Name | color "green" "bold" }} {{ printf "%-40s" $example.Command | color "cyan" "" }}{{ $example.Description }}
   {{- end }}
 
 {{ "FREE FORM ARGUMENTS" | color "" "heading" }}:
@@ -106,8 +106,8 @@ func renderCustomHelp() {
 			{"--ndots=INT", "Specify ndots parameter. Takes value from /etc/resolv.conf if using the system namesever or 1 otherwise."},
 			{"--search", "Use the search list defined in resolv.conf. Defaults to true. Set --search=false to disable search list."},
 			{"--timeout=DURATION", "Specify timeout for the resolver to return a response (e.g., 5s, 400ms, 1m)."},
-			{"-4 --ipv4", "Use IPv4 only."},
-			{"-6 --ipv6", "Use IPv6 only."},
+			{"-4, --ipv4", "Use IPv4 only."},
+			{"-6, --ipv6", "Use IPv6 only."},
 			{"--tls-hostname=HOSTNAME", "Provide a hostname for verification of the certificate if the provided DoT nameserver is an IP."},
 			{"--skip-hostname-verification", "Skip TLS Hostname Verification in case of DOT Lookups."},
 		},

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -105,7 +105,7 @@ func renderCustomHelp() {
 			{"--strategy=STRATEGY", "Specify strategy to query nameserver listed in etc/resolv.conf. (all, random, first)."},
 			{"--ndots=INT", "Specify ndots parameter. Takes value from /etc/resolv.conf if using the system namesever or 1 otherwise."},
 			{"--search", "Use the search list defined in resolv.conf. Defaults to true. Set --search=false to disable search list."},
-			{"--timeout", "Specify timeout (in seconds) for the resolver to return a response."},
+			{"--timeout=DURATION", "Specify timeout for the resolver to return a response (e.g., 5s, 400ms, 1m)."},
 			{"-4 --ipv4", "Use IPv4 only."},
 			{"-6 --ipv6", "Use IPv6 only."},
 			{"--tls-hostname=HOSTNAME", "Provide a hostname for verification of the certificate if the provided DoT nameserver is an IP."},

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
             { label: "Reverse IP Lookups", link: "/features/reverse" },
             { label: "Protocol Tweaks", link: "/features/tweaks" },
             { label: "Shell Completions", link: "/features/shell" },
+            { label: "Common Record Types", link: "/features/any" },
           ],
         },
       ],

--- a/docs/src/content/docs/features/any.md
+++ b/docs/src/content/docs/features/any.md
@@ -1,0 +1,54 @@
+---
+title: Common record types
+description: Learn how to query multiple DNS record types simultaneously
+---
+
+The `--any` flag in Doggo allows you to query all supported DNS record types for a given domain in a single command. This can be particularly useful when you want to get a comprehensive view of a domain's DNS configuration without running multiple queries.
+
+## Syntax
+
+```bash
+doggo [domain] --any
+```
+
+## Supported Record Types
+
+When you use the `--any` flag, Doggo will query for the following common DNS record types:
+
+- A (IPv4 address)
+- AAAA (IPv6 address)
+- CNAME (Canonical name)
+- MX (Mail exchange)
+- NS (Name server)
+- PTR (Pointer)
+- SOA (Start of authority)
+- SRV (Service)
+- TXT (Text)
+- CAA (Certification Authority Authorization)
+
+## Example Usage
+
+```bash
+doggo mrkaran.dev --any
+```
+
+## Example Output
+
+```bash
+$ doggo example.com --any
+NAME            TYPE    CLASS   TTL     ADDRESS                         NAMESERVER
+example.com.    A       IN      3401s   93.184.215.14                           127.0.0.53:53
+example.com.    AAAA    IN      3600s   2606:2800:21f:cb07:6820:80da:af6b:8b2c  127.0.0.53:53
+example.com.    MX      IN      77316s  0 .                                     127.0.0.53:53
+example.com.    NS      IN      86400s  a.iana-servers.net.                     127.0.0.53:53
+example.com.    NS      IN      86400s  b.iana-servers.net.                     127.0.0.53:53
+example.com.    SOA     IN      3600s   ns.icann.org.                           127.0.0.53:53
+                                        noc.dns.icann.org. 2024041841
+                                        7200 3600 1209600 3600
+example.com.    TXT     IN      86400s  "v=spf1 -all"                           127.0.0.53:53
+example.com.    TXT     IN      86400s  "wgyf8z8cgvm2qmxpnbnldrcltvk4xqfn"      127.0.0.53:53
+```
+
+## Considerations
+
+- The `--any` query may take longer to complete compared to querying a single record type, as it's fetching multiple record types.

--- a/docs/src/content/docs/guide/examples.md
+++ b/docs/src/content/docs/guide/examples.md
@@ -80,7 +80,7 @@ These examples showcase how to combine different features for powerful DNS query
 
 14. Use IPv6 only with a specific timeout and DNSSEC checking:
     ```bash
-    doggo AAAA example.com -6 --timeout 5 --do
+    doggo AAAA example.com -6 --timeout 3s --do
     ```
 
 

--- a/docs/src/content/docs/guide/reference.md
+++ b/docs/src/content/docs/guide/reference.md
@@ -23,16 +23,16 @@ doggo [--] [query options] [arguments...]
 
 ## Resolver Options
 
-| Option                         | Description                                                        |
-| ------------------------------ | ------------------------------------------------------------------ |
-| `--strategy=STRATEGY`          | Specify strategy to query nameservers (all, random, first)         |
-| `--ndots=INT`                  | Specify ndots parameter                                            |
-| `--search`                     | Use the search list defined in resolv.conf (default: true)         |
-| `--timeout`                    | Specify timeout (in seconds) for the resolver to return a response |
-| `-4, --ipv4`                   | Use IPv4 only                                                      |
-| `-6, --ipv6`                   | Use IPv6 only                                                      |
-| `--tls-hostname=HOSTNAME`      | Provide a hostname for TLS certificate verification                |
-| `--skip-hostname-verification` | Skip TLS Hostname Verification for DoT lookups                     |
+| Option                         | Description                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------- |
+| `--strategy=STRATEGY`          | Specify strategy to query nameservers (all, random, first)                  |
+| `--ndots=INT`                  | Specify ndots parameter                                                     |
+| `--search`                     | Use the search list defined in resolv.conf (default: true)                  |
+| `--timeout=DURATION`           | Specify timeout for the resolver to return a response (e.g., 5s, 400ms, 1m) |
+| `-4, --ipv4`                   | Use IPv4 only                                                               |
+| `-6, --ipv6`                   | Use IPv6 only                                                               |
+| `--tls-hostname=HOSTNAME`      | Provide a hostname for TLS certificate verification                         |
+| `--skip-hostname-verification` | Skip TLS Hostname Verification for DoT lookups                              |
 
 ## Query Flags
 

--- a/docs/src/content/docs/resolvers/system.md
+++ b/docs/src/content/docs/resolvers/system.md
@@ -60,7 +60,7 @@ Available strategies:
 --ndots=INT             Specify ndots parameter. Takes value from /etc/resolv.conf if using the system nameserver or 1 otherwise.
 --search                Use the search list defined in resolv.conf. Defaults to true. Set --search=false to disable search list.
 --strategy=STRATEGY     Specify strategy to query nameservers listed in /etc/resolv.conf. Options: all, first, random. Defaults to all.
---timeout=SECONDS       Set the timeout for resolver responses.
+--timeout=DURATION    Set the timeout for resolver responses (e.g., 5s, 400ms, 1m).
 ```
 
 ## Examples
@@ -77,7 +77,7 @@ Available strategies:
 
 3. Use system resolver with 'first' strategy and custom timeout:
    ```bash
-   doggo example.com --strategy=first --timeout=5
+   doggo example.com --strategy=first --timeout=2s
    ```
 
 4. Override system resolver and use specific nameservers:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/knadh/koanf/parsers/toml v0.1.0
 	github.com/knadh/koanf/providers/env v0.1.0
-	github.com/knadh/koanf/providers/file v0.1.0
+	github.com/knadh/koanf/providers/file v1.0.0
 	github.com/knadh/koanf/providers/posflag v0.1.0
 	github.com/knadh/koanf/v2 v2.1.1
 	github.com/miekg/dns v1.1.61

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/knadh/koanf/parsers/toml v0.1.0 h1:S2hLqS4TgWZYj4/7mI5m1CQQcWurxUz6OD
 github.com/knadh/koanf/parsers/toml v0.1.0/go.mod h1:yUprhq6eo3GbyVXFFMdbfZSo928ksS+uo0FFqNMnO18=
 github.com/knadh/koanf/providers/env v0.1.0 h1:LqKteXqfOWyx5Ab9VfGHmjY9BvRXi+clwyZozgVRiKg=
 github.com/knadh/koanf/providers/env v0.1.0/go.mod h1:RE8K9GbACJkeEnkl8L/Qcj8p4ZyPXZIQ191HJi44ZaQ=
-github.com/knadh/koanf/providers/file v0.1.0 h1:fs6U7nrV58d3CFAFh8VTde8TM262ObYf3ODrc//Lp+c=
-github.com/knadh/koanf/providers/file v0.1.0/go.mod h1:rjJ/nHQl64iYCtAW2QQnF0eSmDEX/YZ/eNFj5yR6BvA=
+github.com/knadh/koanf/providers/file v1.0.0 h1:DtPvSQBeF+N0QLPMz0yf2bx0nFSxUcncpqQvzCxfCyk=
+github.com/knadh/koanf/providers/file v1.0.0/go.mod h1:/faSBcv2mxPVjFrXck95qeoyoZ5myJ6uxN8OOVNJJCI=
 github.com/knadh/koanf/providers/posflag v0.1.0 h1:mKJlLrKPcAP7Ootf4pBZWJ6J+4wHYujwipe7Ie3qW6U=
 github.com/knadh/koanf/providers/posflag v0.1.0/go.mod h1:SYg03v/t8ISBNrMBRMlojH8OsKowbkXV7giIbBVgbz0=
 github.com/knadh/koanf/v2 v2.1.1 h1:/R8eXqasSTsmDCsAyYj+81Wteg8AqrV9CP6gvsTsOmM=

--- a/internal/app/questions.go
+++ b/internal/app/questions.go
@@ -5,13 +5,16 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/mr-karan/doggo/pkg/models"
 )
 
 // LoadFallbacks sets fallbacks for options
 // that are not specified by the user but necessary
 // for the resolver.
 func (app *App) LoadFallbacks() {
-	if len(app.QueryFlags.QTypes) == 0 {
+	if app.QueryFlags.QueryAny {
+		app.QueryFlags.QTypes = models.GetCommonRecordTypes()
+	} else if len(app.QueryFlags.QTypes) == 0 {
 		app.QueryFlags.QTypes = append(app.QueryFlags.QTypes, "A")
 	}
 	if len(app.QueryFlags.QClasses) == 0 {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 const (
 	// DefaultTLSPort specifies the default port for a DNS server connecting over TCP over TLS.
@@ -39,6 +42,7 @@ type QueryFlags struct {
 	Strategy           string        `koanf:"strategy" strategy:"-"`
 	InsecureSkipVerify bool          `koanf:"skip-hostname-verification" skip-hostname-verification:"-"`
 	TLSHostname        string        `koanf:"tls-hostname" tls-hostname:"-"`
+	QueryAny           bool          `koanf:"any" json:"any"`
 }
 
 // Nameserver represents the type of Nameserver
@@ -46,4 +50,12 @@ type QueryFlags struct {
 type Nameserver struct {
 	Address string
 	Type    string
+}
+
+// CommonRecordTypes is a string containing all common DNS record types
+const CommonRecordTypes = "A AAAA CNAME MX NS PTR SOA SRV TXT CAA"
+
+// GetCommonRecordTypes returns a slice of common DNS record types
+func GetCommonRecordTypes() []string {
+	return strings.Fields(CommonRecordTypes)
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -20,6 +20,8 @@ const (
 	DOTResolver      = "dot"
 	DNSCryptResolver = "dnscrypt"
 	DOQResolver      = "doq"
+	// CommonRecordTypes is a string containing all common DNS record types
+	CommonRecordTypes = "A AAAA CNAME MX NS PTR SOA SRV TXT CAA"
 )
 
 // QueryFlags is used store the query params
@@ -51,9 +53,6 @@ type Nameserver struct {
 	Address string
 	Type    string
 }
-
-// CommonRecordTypes is a string containing all common DNS record types
-const CommonRecordTypes = "A AAAA CNAME MX NS PTR SOA SRV TXT CAA"
 
 // GetCommonRecordTypes returns a slice of common DNS record types
 func GetCommonRecordTypes() []string {

--- a/pkg/resolvers/common.go
+++ b/pkg/resolvers/common.go
@@ -1,0 +1,42 @@
+package resolvers
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/miekg/dns"
+)
+
+// QueryFunc represents the signature of a query function
+type QueryFunc func(question dns.Question, flags QueryFlags) (Response, error)
+
+// ConcurrentLookup performs concurrent DNS lookups
+func ConcurrentLookup(questions []dns.Question, flags QueryFlags, queryFunc QueryFunc, logger *slog.Logger) ([]Response, error) {
+	var wg sync.WaitGroup
+	responses := make([]Response, len(questions))
+	errors := make([]error, len(questions))
+
+	for i, q := range questions {
+		wg.Add(1)
+		go func(i int, q dns.Question) {
+			defer wg.Done()
+			resp, err := queryFunc(q, flags)
+			responses[i] = resp
+			errors[i] = err
+		}(i, q)
+	}
+
+	wg.Wait()
+
+	// Collect non-nil responses and handle errors
+	var validResponses []Response
+	for i, resp := range responses {
+		if errors[i] != nil {
+			logger.Error("error in lookup", "error", errors[i])
+		} else {
+			validResponses = append(validResponses, resp)
+		}
+	}
+
+	return validResponses, nil
+}

--- a/pkg/resolvers/common.go
+++ b/pkg/resolvers/common.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 
@@ -8,34 +9,56 @@ import (
 )
 
 // QueryFunc represents the signature of a query function
-type QueryFunc func(question dns.Question, flags QueryFlags) (Response, error)
+type QueryFunc func(ctx context.Context, question dns.Question, flags QueryFlags) (Response, error)
 
 // ConcurrentLookup performs concurrent DNS lookups
-func ConcurrentLookup(questions []dns.Question, flags QueryFlags, queryFunc QueryFunc, logger *slog.Logger) ([]Response, error) {
+func ConcurrentLookup(ctx context.Context, questions []dns.Question, flags QueryFlags, queryFunc QueryFunc, logger *slog.Logger) ([]Response, error) {
 	var wg sync.WaitGroup
 	responses := make([]Response, len(questions))
 	errors := make([]error, len(questions))
+	done := make(chan struct{})
 
 	for i, q := range questions {
 		wg.Add(1)
 		go func(i int, q dns.Question) {
 			defer wg.Done()
-			resp, err := queryFunc(q, flags)
-			responses[i] = resp
-			errors[i] = err
+			select {
+			case <-ctx.Done():
+				errors[i] = ctx.Err()
+			default:
+				resp, err := queryFunc(ctx, q, flags)
+				responses[i] = resp
+				errors[i] = err
+			}
 		}(i, q)
 	}
 
-	wg.Wait()
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-done:
+		// All goroutines have finished
+	}
 
 	// Collect non-nil responses and handle errors
 	var validResponses []Response
 	for i, resp := range responses {
 		if errors[i] != nil {
-			logger.Error("error in lookup", "error", errors[i])
+			if errors[i] != context.Canceled && errors[i] != context.DeadlineExceeded {
+				logger.Error("error in lookup", "error", errors[i])
+			}
 		} else {
 			validResponses = append(validResponses, resp)
 		}
+	}
+
+	if len(validResponses) == 0 && ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
 	return validResponses, nil

--- a/pkg/resolvers/dnscrypt.go
+++ b/pkg/resolvers/dnscrypt.go
@@ -40,9 +40,13 @@ func NewDNSCryptResolver(server string, dnscryptOpts DNSCryptResolverOpts, resol
 	}, nil
 }
 
-// Lookup takes a dns.Question and sends them to DNS Server.
-// It parses the Response from the server in a custom output format.
-func (r *DNSCryptResolver) Lookup(question dns.Question, flags QueryFlags) (Response, error) {
+// Lookup implements the Resolver interface
+func (r *DNSCryptResolver) Lookup(questions []dns.Question, flags QueryFlags) ([]Response, error) {
+	return ConcurrentLookup(questions, flags, r.query, r.resolverOptions.Logger)
+}
+
+// query performs a single DNS query
+func (r *DNSCryptResolver) query(question dns.Question, flags QueryFlags) (Response, error) {
 	var (
 		rsp      Response
 		messages = prepareMessages(question, flags, r.resolverOptions.Ndots, r.resolverOptions.SearchList)

--- a/pkg/resolvers/doh.go
+++ b/pkg/resolvers/doh.go
@@ -46,9 +46,9 @@ func NewDOHResolver(server string, resolverOpts Options) (Resolver, error) {
 	}, nil
 }
 
-// Lookup takes a dns.Question and sends them to DNS Server.
+// query takes a dns.Question and sends them to DNS Server.
 // It parses the Response from the server in a custom output format.
-func (r *DOHResolver) Lookup(question dns.Question, flags QueryFlags) (Response, error) {
+func (r *DOHResolver) query(question dns.Question, flags QueryFlags) (Response, error) {
 	var (
 		rsp      Response
 		messages = prepareMessages(question, flags, r.resolverOptions.Ndots, r.resolverOptions.SearchList)
@@ -122,4 +122,9 @@ func (r *DOHResolver) Lookup(question dns.Question, flags QueryFlags) (Response,
 		}
 	}
 	return rsp, nil
+}
+
+// Lookup implements the Resolver interface
+func (r *DOHResolver) Lookup(questions []dns.Question, flags QueryFlags) ([]Response, error) {
+	return ConcurrentLookup(questions, flags, r.query, r.resolverOptions.Logger)
 }

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -34,9 +34,14 @@ func NewDOQResolver(server string, resolverOpts Options) (Resolver, error) {
 	}, nil
 }
 
+// Lookup implements the Resolver interface
+func (r *DOQResolver) Lookup(questions []dns.Question, flags QueryFlags) ([]Response, error) {
+	return ConcurrentLookup(questions, flags, r.query, r.resolverOptions.Logger)
+}
+
 // Lookup takes a dns.Question and sends them to DNS Server.
 // It parses the Response from the server in a custom output format.
-func (r *DOQResolver) Lookup(question dns.Question, flags QueryFlags) (Response, error) {
+func (r *DOQResolver) query(question dns.Question, flags QueryFlags) (Response, error) {
 	var (
 		rsp      Response
 		messages = prepareMessages(question, flags, r.resolverOptions.Ndots, r.resolverOptions.SearchList)

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/miekg/dns"
@@ -35,19 +33,19 @@ func NewDOQResolver(server string, resolverOpts Options) (Resolver, error) {
 }
 
 // Lookup implements the Resolver interface
-func (r *DOQResolver) Lookup(questions []dns.Question, flags QueryFlags) ([]Response, error) {
-	return ConcurrentLookup(questions, flags, r.query, r.resolverOptions.Logger)
+func (r *DOQResolver) Lookup(ctx context.Context, questions []dns.Question, flags QueryFlags) ([]Response, error) {
+	return ConcurrentLookup(ctx, questions, flags, r.query, r.resolverOptions.Logger)
 }
 
-// Lookup takes a dns.Question and sends them to DNS Server.
+// query takes a dns.Question and sends them to DNS Server.
 // It parses the Response from the server in a custom output format.
-func (r *DOQResolver) query(question dns.Question, flags QueryFlags) (Response, error) {
+func (r *DOQResolver) query(ctx context.Context, question dns.Question, flags QueryFlags) (Response, error) {
 	var (
 		rsp      Response
 		messages = prepareMessages(question, flags, r.resolverOptions.Ndots, r.resolverOptions.SearchList)
 	)
 
-	session, err := quic.DialAddr(context.TODO(), r.server, r.tls, nil)
+	session, err := quic.DialAddr(ctx, r.server, r.tls, nil)
 	if err != nil {
 		return rsp, err
 	}
@@ -64,54 +62,56 @@ func (r *DOQResolver) query(question dns.Question, flags QueryFlags) (Response, 
 		msg.Id = 0
 
 		// get the DNS Message in wire format.
-		var b []byte
-		b, err = msg.Pack()
+		b, err := msg.Pack()
 		if err != nil {
 			return rsp, err
 		}
 		now := time.Now()
 
-		var stream quic.Stream
-		stream, err = session.OpenStream()
+		stream, err := session.OpenStreamSync(ctx)
 		if err != nil {
 			return rsp, err
 		}
+		defer stream.Close()
 
-		var msgLen = uint16(len(b))
-		var msgLenBytes = []byte{byte(msgLen >> 8), byte(msgLen & 0xFF)}
-		_, err = stream.Write(msgLenBytes)
-		if err != nil {
+		msgLen := uint16(len(b))
+		msgLenBytes := []byte{byte(msgLen >> 8), byte(msgLen & 0xFF)}
+		if _, err = stream.Write(msgLenBytes); err != nil {
 			return rsp, err
 		}
 		// Make a QUIC request to the DNS server with the DNS message as wire format bytes in the body.
-		_, err = stream.Write(b)
-		if err != nil {
+		if _, err = stream.Write(b); err != nil {
 			return rsp, err
 		}
 
-		err = stream.SetDeadline(time.Now().Add(r.resolverOptions.Timeout))
-		if err != nil {
-			return rsp, err
-		}
+		// Use a separate context with timeout for reading the response
+		readCtx, cancel := context.WithTimeout(ctx, r.resolverOptions.Timeout)
+		defer cancel()
 
 		var buf []byte
-		buf, err = io.ReadAll(stream)
-		if err != nil {
-			if errors.Is(err, os.ErrDeadlineExceeded) {
-				return rsp, fmt.Errorf("timeout")
-			}
-			return rsp, err
-		}
-		rtt := time.Since(now)
+		errChan := make(chan error, 1)
+		go func() {
+			var err error
+			buf, err = io.ReadAll(stream)
+			errChan <- err
+		}()
 
-		_ = stream.Close()
+		select {
+		case err := <-errChan:
+			if err != nil {
+				return rsp, err
+			}
+		case <-readCtx.Done():
+			return rsp, fmt.Errorf("timeout reading response")
+		}
+
+		rtt := time.Since(now)
 
 		packetLen := binary.BigEndian.Uint16(buf[:2])
 		if packetLen != uint16(len(buf[2:])) {
 			return rsp, fmt.Errorf("packet length mismatch")
 		}
-		err = msg.Unpack(buf[2:])
-		if err != nil {
+		if err = msg.Unpack(buf[2:]); err != nil {
 			return rsp, err
 		}
 		// pack questions in output.
@@ -131,6 +131,14 @@ func (r *DOQResolver) query(question dns.Question, flags QueryFlags) (Response, 
 		if len(output.Answers) > 0 {
 			// stop iterating the searchlist.
 			break
+		}
+
+		// Check if context is done after each iteration
+		select {
+		case <-ctx.Done():
+			return rsp, ctx.Err()
+		default:
+			// Continue to next iteration
 		}
 	}
 	return rsp, nil

--- a/pkg/resolvers/resolver.go
+++ b/pkg/resolvers/resolver.go
@@ -28,7 +28,7 @@ type Options struct {
 // Client. Different types of providers can load
 // a DNS Resolver satisfying this interface.
 type Resolver interface {
-	Lookup(dns.Question, QueryFlags) (Response, error)
+	Lookup([]dns.Question, QueryFlags) ([]Response, error)
 }
 
 // Response represents a custom output format

--- a/pkg/resolvers/resolver.go
+++ b/pkg/resolvers/resolver.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -28,7 +29,7 @@ type Options struct {
 // Client. Different types of providers can load
 // a DNS Resolver satisfying this interface.
 type Resolver interface {
-	Lookup([]dns.Question, QueryFlags) ([]Response, error)
+	Lookup(ctx context.Context, questions []dns.Question, flags QueryFlags) ([]Response, error)
 }
 
 // Response represents a custom output format

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -97,8 +97,8 @@ func handleLookup(w http.ResponseWriter, r *http.Request) {
 		RD: true,
 	}
 
-	// ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	// defer cancel()
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
 
 	var (
 		wg           sync.WaitGroup
@@ -111,7 +111,7 @@ func handleLookup(w http.ResponseWriter, r *http.Request) {
 		wg.Add(1)
 		go func(r resolvers.Resolver) {
 			defer wg.Done()
-			responses, err := r.Lookup(app.Questions, queryFlags)
+			responses, err := r.Lookup(ctx, app.Questions, queryFlags)
 			mu.Lock()
 			if err != nil {
 				allErrors = append(allErrors, err)


### PR DESCRIPTION
Using `--any` it will query multiple common record types.

```
./bin/doggo.bin example.com --any
NAME            TYPE    CLASS   TTL     ADDRESS                                 NAMESERVER
example.com.    A       IN      1152s   93.184.215.14                           127.0.0.53:53
example.com.    AAAA    IN      1138s   2606:2800:21f:cb07:6820:80da:af6b:8b2c  127.0.0.53:53
example.com.    MX      IN      7196s   0 .                                     127.0.0.53:53
example.com.    NS      IN      7196s   b.iana-servers.net.                     127.0.0.53:53
example.com.    NS      IN      7196s   a.iana-servers.net.                     127.0.0.53:53
example.com.    SOA     IN      3596s   ns.icann.org.                           127.0.0.53:53
                                        noc.dns.icann.org. 2024041841
                                        7200 3600 1209600 3600
example.com.    TXT     IN      7197s   "wgyf8z8cgvm2qmxpnbnldrcltvk4xqfn"      127.0.0.53:53
example.com.    TXT     IN      7197s   "v=spf1 -all"                           127.0.0.53:53
```