### PR TITLE
Updating canonical URL

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig, passthroughImageService } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   base: "/docs",
-  site: "https://doggo.karan.dev/docs",
+  site: "https://doggo.mrkaran.dev/docs/",
   image: {
     service: passthroughImageService(),
   },


### PR DESCRIPTION
I was reading the docs, and emailed this link to myself using the iOS share sheet: `https://doggo.mrkaran.dev/docs/`. When I got the email, the link had been changed to `https://doggo.karan.dev/docs` which is the canonical link based on the `site` setting in `docs/astro.config.mjs`. This link doesn't work, however. Here's an update so the
canonical URL will be correct.