### PR TITLE
Fix zsh completions

### DIFF
--- a/cmd/doggo/completions.go
+++ b/cmd/doggo/completions.go
@@ -48,8 +48,7 @@ _doggo() {
 complete -F _doggo doggo
 `
 
-	zshCompletion = `
-#compdef doggo
+	zshCompletion = `#compdef doggo
 
 _doggo() {
   local -a commands


### PR DESCRIPTION
Fixes #133

Remove the blank line at the start that prevents ZSH from treating this as a completion file.

From https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files
> Files whose first line does not start with one of these tags are not considered to be part of the completion system