### PR TITLE
fix(logger): Change log destination to stderr

### DIFF
--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -16,6 +16,6 @@ func InitLogger(debug bool) *slog.Logger {
 		Level: lvl,
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, lgrOpts))
+	logger := slog.New(slog.NewTextHandler(os.Stderr, lgrOpts))
 	return logger
 }


### PR DESCRIPTION
Logs are currently sent to stdout, which isn't ideal if doggo is used in shell scripts. If doggo fails and the exit code is not checked, then the error log will be assigned to a variable. This PR changes logs to write to `os.Stderr`.