### PR TITLE
fix: change DefaultResolvConfPath to var instead of const

### DIFF
--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DefaultResolvConfPath specifies path to default resolv config file on UNIX.
-const DefaultResolvConfPath = "/etc/resolv.conf"
+var DefaultResolvConfPath = "/etc/resolv.conf"
 
 // GetDefaultServers get system default nameserver
 func GetDefaultServers() ([]string, int, []string, error) {


### PR DESCRIPTION
This change allows users to override the default resolv.conf path by `-ldflags '-X "github.com/mr-karan/doggo/pkg/config.DefaultResolvConfPath=/another/path/to/resolv.conf"'`