### PR TITLE
configure rootcas for doh and doq resolvers

### DIFF
--- a/pkg/resolvers/doh.go
+++ b/pkg/resolvers/doh.go
@@ -35,6 +35,7 @@ func NewDOHResolver(server string, resolverOpts Options) (Resolver, error) {
 	transport.TLSClientConfig = &tls.Config{
 		ServerName:         resolverOpts.TLSHostname,
 		InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+		RootCAs:            resolverOpts.RootCAs,
 	}
 	httpClient := &http.Client{
 		Timeout:   resolverOpts.Timeout,

--- a/pkg/resolvers/doq.go
+++ b/pkg/resolvers/doq.go
@@ -26,6 +26,7 @@ func NewDOQResolver(server string, resolverOpts Options) (Resolver, error) {
 			NextProtos:         []string{"doq"},
 			ServerName:         resolverOpts.TLSHostname,
 			InsecureSkipVerify: resolverOpts.InsecureSkipVerify,
+			RootCAs:            resolverOpts.RootCAs,
 		},
 		server:          server,
 		resolverOptions: resolverOpts,

--- a/pkg/resolvers/resolver.go
+++ b/pkg/resolvers/resolver.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"crypto/x509"
 	"log/slog"
 	"time"
 
@@ -23,6 +24,7 @@ type Options struct {
 	Strategy           string
 	InsecureSkipVerify bool
 	TLSHostname        string
+	RootCAs            *x509.CertPool
 }
 
 // Resolver implements the configuration for a DNS


### PR DESCRIPTION
DoQ and DoH/3 nameservers aren't always served with TLS certs rooted in known, public sources of trust.

This PR adds support for configuring custom `RootCAs` on DOH and DOT resolvers.