### PR TITLE
Add -1/-single flag

### DIFF
--- a/cmd/doggo/cli.go
+++ b/cmd/doggo/cli.go
@@ -55,6 +55,8 @@ func main() {
 			err = app.OutputGlobalpingJSON(res)
 		} else if app.QueryFlags.ShortOutput {
 			err = app.OutputGlobalpingShort(res)
+		} else if app.QueryFlags.SingleOutput {
+			err = app.OutputGlobalpingSingle(res)
 		} else {
 			err = app.OutputGlobalping(res)
 		}
@@ -159,6 +161,7 @@ func setupFlags() *flag.FlagSet {
 
 	f.BoolP("json", "J", false, "Set the output format as JSON")
 	f.Bool("short", false, "Short output format")
+	f.BoolP("single", "1", false, "Single output format")
 	f.Bool("time", false, "Display how long the response took")
 	f.Bool("color", true, "Show colored output")
 	f.Bool("debug", false, "Enable debug mode")

--- a/cmd/doggo/completions.go
+++ b/cmd/doggo/completions.go
@@ -13,7 +13,7 @@ _doggo() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    opts="-v --version -h --help -q --query -t --type -n --nameserver -c --class -r --reverse --strategy --ndots --search --timeout -4 --ipv4 -6 --ipv6 --tls-hostname --skip-hostname-verification -J --json --short --color --debug --time --gp-from --gp-limit"
+    opts="-v --version -h --help -q --query -t --type -n --nameserver -c --class -r --reverse --strategy --ndots --search --timeout -4 --ipv4 -6 --ipv6 --tls-hostname --skip-hostname-verification -J --json --short -1 --single --color --debug --time --gp-from --gp-limit"
 
     case "${prev}" in
         -t|--type)
@@ -74,6 +74,7 @@ _doggo() {
     '--skip-hostname-verification[Skip TLS hostname verification in case of DoT lookups]' \
     '(-J --json)'{-J,--json}'[Format the output as JSON]' \
     '--short[Shows only the response section in the output]' \
+    '(-1 --single)'{-1,--single}'[Shows only the single address]' \
     '--color[Colored output]:setting:(true false)' \
     '--debug[Enable debug logging]' \
     '--time[Shows how long the response took from the server]' \
@@ -125,6 +126,7 @@ complete -c doggo -n '__fish_doggo_no_subcommand' -s '6' -l 'ipv6' -d "Use IPv6 
 # Output options
 complete -c doggo -n '__fish_doggo_no_subcommand' -s 'J' -l 'json'  -d "Format the output as JSON"
 complete -c doggo -n '__fish_doggo_no_subcommand' -l 'short'        -d "Shows only the response section in the output"
+complete -c doggo -n '__fish_doggo_no_subcommand' -s '1' -l 'single' -d "Shows only the single address"
 complete -c doggo -n '__fish_doggo_no_subcommand' -l 'color'        -d "Colored output" -x -a "true false"
 complete -c doggo -n '__fish_doggo_no_subcommand' -l 'debug'        -d "Enable debug logging"
 complete -c doggo -n '__fish_doggo_no_subcommand' -l 'time'         -d "Shows how long the response took from the server"

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -136,6 +136,7 @@ func renderCustomHelp() {
 		"OutputOptions": []Option{
 			{"-J, --json", "Format the output as JSON."},
 			{"--short", "Short output format. Shows only the response section."},
+			{"-1, --single", "Single output format. Shows only the single address."},
 			{"--color", "Defaults to true. Set --color=false to disable colored output."},
 			{"--debug", "Enable debug logging."},
 			{"--time", "Shows how long the response took from the server."},

--- a/docs/src/content/docs/features/output.md
+++ b/docs/src/content/docs/features/output.md
@@ -1,6 +1,6 @@
 ---
 title: Output Formats
-description: Learn about Doggo's various output formats including colored, JSON, and short outputs
+description: Learn about Doggo's various output formats including colored, JSON, short, and single outputs
 ---
 
 Doggo provides flexible output formats to suit different use cases, from human-readable colored output to machine-parsable JSON.
@@ -130,5 +130,14 @@ Frankfurt, DE, EU, WIBO Baltic UAB (AS59939)
 172.67.187.239
 Saratov, RU, AS, LLC "SMART CENTER" (AS48763)
 172.67.187.239
+104.21.7.168
+```
+
+### Single Output
+
+The `--single` or `-1` flag is similar to `--short` flag, but show only the single address:
+
+```bash
+doggo mrkaran.dev --single
 104.21.7.168
 ```

--- a/docs/src/content/docs/guide/reference.md
+++ b/docs/src/content/docs/guide/reference.md
@@ -47,13 +47,14 @@ doggo [--] [query options] [arguments...]
 
 ## Output Options
 
-| Option       | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| `-J, --json` | Format the output as JSON                             |
-| `--short`    | Short output format (shows only the response section) |
-| `--color`    | Enable/disable colored output (default: true)         |
-| `--debug`    | Enable debug logging                                  |
-| `--time`     | Show query response time                              |
+| Option         | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `-J, --json`   | Format the output as JSON                             |
+| `--short`      | Short output format (shows only the response section) |
+| `-1, --single` | Single output format (shows only the single address)  |
+| `--color`      | Enable/disable colored output (default: true)         |
+| `--debug`      | Enable debug logging                                  |
+| `--time`       | Show query response time                              |
 
 ## Transport Options
 

--- a/internal/app/globalping.go
+++ b/internal/app/globalping.go
@@ -145,6 +145,23 @@ func (app *App) OutputGlobalpingShort(m *globalping.Measurement) error {
 	return nil
 }
 
+func (app *App) OutputGlobalpingSingle(m *globalping.Measurement) error {
+	var addresses []string
+	for i := range m.Results {
+		answers, err := globalping.DecodeDNSAnswers(m.Results[i].Result.AnswersRaw)
+		if err != nil {
+			return err
+		}
+		for _, ans := range answers {
+			addresses = append(addresses, ans.Value)
+		}
+	}
+	if len(addresses) != 0 {
+		fmt.Printf("%s\n", selectAddress(addresses))
+	}
+	return nil
+}
+
 type GlobalpingOutputResponse struct {
 	Location string             `json:"location"`
 	Answers  []resolvers.Answer `json:"answers"`

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -44,6 +44,18 @@ func (app *App) outputShort(rsp []resolvers.Response) {
 	}
 }
 
+func (app *App) outputSingle(rsp []resolvers.Response) {
+	var addresses []string
+	for _, r := range rsp {
+		for _, a := range r.Answers {
+			addresses = append(addresses, a.Address)
+		}
+	}
+	if len(addresses) != 0 {
+		fmt.Printf("%s\n", selectAddress(addresses))
+	}
+}
+
 func (app *App) outputTerminal(rsp []resolvers.Response) {
 	// Disables colorized output if user specified.
 	if !app.QueryFlags.Color {
@@ -153,6 +165,8 @@ func (app *App) Output(responses []resolvers.Response) {
 		app.outputJSON(responses)
 	} else if app.QueryFlags.ShortOutput {
 		app.outputShort(responses)
+	} else if app.QueryFlags.SingleOutput {
+		app.outputSingle(responses)
 	} else {
 		app.outputTerminal(responses)
 	}

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+func selectAddress(addresses []string) string {
+	n := big.NewInt(int64(len(addresses)))
+	i, err := rand.Int(rand.Reader, n)
+	if err != nil {
+		panic(fmt.Sprintf("crypto/rand: %v", err))
+	} else if !i.IsInt64() {
+		panic("crypto/rand: out of range")
+	}
+	return addresses[i.Int64()]
+}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -39,6 +39,7 @@ type QueryFlags struct {
 	DisplayTimeTaken   bool          `koanf:"time" json:"-"`
 	ShowJSON           bool          `koanf:"json" json:"-"`
 	ShortOutput        bool          `koanf:"short" short:"-"`
+	SingleOutput       bool          `koanf:"single" json:"-"`
 	UseSearchList      bool          `koanf:"search" json:"-"`
 	ReverseLookup      bool          `koanf:"reverse" reverse:"-"`
 	Strategy           string        `koanf:"strategy" strategy:"-"`


### PR DESCRIPTION
This PR adds support for the `-1`, `--single` flag, which causes doggo to show the only single (randomly selected) address in the response. This is useful for scripting.

```sh
$ IPADDRESS="$(doggo -1 mrkaran.dev)"
$ echo $IPADDRESS
104.21.7.168
```