### PR TITLE
fix: Enhance install.sh validation with file command test to improve error handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,6 +102,12 @@ download_and_install() {
     exit 1
   fi
 
+  info "Verifying if file command exists"
+  if ! command -v asfile > /dev/null 2>&1; then
+      error "'file' command not found. Please install it."
+      exit 1
+  fi
+
   info "Verifying downloaded file..."
   if [ "${platform}" = "Windows" ]; then
     if ! file "${filename}" | grep -q "Zip archive data"; then


### PR DESCRIPTION
When running the installation script via:

```bash
curl -sS https://raw.githubusercontent.com/mr-karan/doggo/main/install.sh | sh
```

the script exited with the following error on systems where the `file` command is not installed:

```
main: line 115: file: command not found
x Downloaded file is not in gzip format. Installation failed.
x File type
```

This behavior was confusing and unhelpful for users without the `file` utility.

#### fix

* Adds a POSIX-compliant check for the `file` command at the beginning of the script.
* If `file` is missing, the script now exits early with a clear error message instructing the user to install it.

####  Example new output:
```
x 'file' command not found. Please install it..
```

This makes the install process more robust and user-friendly, especially in minimal enviroments such as toolbox, alpine etc....

