### PR TITLE
Don't run the zsh completion function when being source-ed or eval-ed

### DIFF
--- a/cmd/doggo/completions.go
+++ b/cmd/doggo/completions.go
@@ -91,7 +91,10 @@ _doggo() {
   return ret
 }
 
-_doggo
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_doggo" ]; then
+  _doggo
+fi
 `
 
 	fishCompletion = `


### PR DESCRIPTION
otherwise `_arguments:comparguments:327: can only be called from
completion function`
