### PR TITLE
fix: installer: better arch detection for 32bit ARM systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ detect_arch() {
   case "${arch}" in
     x86_64) arch="x86_64" ;;
     aarch64|arm64) arch="arm64" ;;
+    armv6l|armv7l|armv8l) arch="arm" ;;
     *)
       error "Unsupported architecture: ${arch}"
       exit 1


### PR DESCRIPTION
This PR updates the installer by explicitly matching 32bit ARM architectures to the generic arm binary that is published as part of the release flow.

Before this change, using the installer on older hardware (most notably a Raspberry Pi 3b+ running a 32bit OS), `uname -m` returns `armv7l` and not `arm`, which results in the installer reporting that the architecture is unsupported.

Now it correctly installs the generic `arm` binary, which works great.

I have tested this on my Raspberry Pi 3b+ running the 32bit Raspberry Pi OS

```bash
$ uname -a
Linux pi 6.12.34+rpt-rpi-v7 #1 SMP Raspbian 1:6.12.34-1+rpt1~bookworm (2025-06-26) armv7l GNU/Linux
```