### PR TITLE
chore: installer: don’t log extraction progress on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ download_and_install() {
       exit 1
     fi
   else
-    if ! tar -xzvf "${filename}" -C "${extract_dir}"; then
+    if ! tar -xzf "${filename}" -C "${extract_dir}"; then
       error "Failed to extract ${filename}"
       rm -rf "${filename}" "${extract_dir}"
       exit 1


### PR DESCRIPTION
This PR removes the `v` flag from the extraction command on linux (`tar`) to not print a line for every file that has been extracted.

The installer has this nice and clean log format and the extraction process breaks that up. Furthermore, since the extracted files are removed completely at the end, there’s no point in listing what has been extracted.

I don’t know how `unzip` behaves on Windows and don’t have a machine to test that, so this only changes the Linux version.

Before:

```
[…]
> Extracting doggo_1.1.1_Linux_arm.tar.gz...
doggo_1.1.1_Linux_arm/LICENSE
doggo_1.1.1_Linux_arm/README.md
doggo_1.1.1_Linux_arm/doggo
> Installing doggo...
> Cleaning up...
[…]
```

After:

```
[…]
> Extracting doggo_1.1.1_Linux_arm.tar.gz...
> Installing doggo...
> Cleaning up...
[…]
```
