### PR TITLE
feat: add --authoritative/-A flag to query the domain's authoritative nameserver

### DIFF
--- a/cmd/doggo/cli.go
+++ b/cmd/doggo/cli.go
@@ -182,6 +182,7 @@ func setupFlags() *flag.FlagSet {
 	f.Bool("skip-hostname-verification", false, "Skip TLS Hostname Verification")
 
 	f.Bool("any", false, "Query all supported DNS record types")
+	f.BoolP("authoritative", "A", false, "Automatically query the authoritative nameserver for the domain")
 
 	f.BoolP("json", "J", false, "Set the output format as JSON")
 	f.Bool("short", false, "Short output format")

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -119,6 +119,7 @@ func renderCustomHelp() {
 			{"-c, --class=CLASS", "Network class of the DNS record (IN, CH, HS etc)."},
 			{"-x, --reverse", "Performs a DNS Lookup for an IPv4 or IPv6 address. Sets the query type and class to PTR and IN respectively."},
 			{"--any", "Query all supported DNS record types (A, AAAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, CAA)."},
+			{"-A, --authoritative", "Automatically find and query the authoritative nameserver for the domain."},
 		},
 		"ResolverOptions": []Option{
 			{"--strategy=STRATEGY", "Specify strategy to query nameservers. Options: all, random, first, internal (RFC 1918/ULA private IPs only)."},

--- a/cmd/doggo/help.go
+++ b/cmd/doggo/help.go
@@ -119,7 +119,7 @@ func renderCustomHelp() {
 			{"-c, --class=CLASS", "Network class of the DNS record (IN, CH, HS etc)."},
 			{"-x, --reverse", "Performs a DNS Lookup for an IPv4 or IPv6 address. Sets the query type and class to PTR and IN respectively."},
 			{"--any", "Query all supported DNS record types (A, AAAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, CAA)."},
-			{"-A, --authoritative", "Automatically find and query the authoritative nameserver for the domain."},
+			{"-A, --authoritative", "Find the domain's zone via SOA and query its delegated authoritative nameservers (the NS RRset). Honours --strategy to narrow the set."},
 		},
 		"ResolverOptions": []Option{
 			{"--strategy=STRATEGY", "Specify strategy to query nameservers. Options: all, random, first, internal (RFC 1918/ULA private IPs only)."},

--- a/internal/app/nameservers.go
+++ b/internal/app/nameservers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ameshkov/dnsstamps"
+	"github.com/miekg/dns"
 	"github.com/mr-karan/doggo/pkg/config"
 	"github.com/mr-karan/doggo/pkg/models"
 )
@@ -39,8 +40,11 @@ func (app *App) LoadNameservers() error {
 		}
 	}
 
-	// If no nameservers were successfully loaded, fall back to system nameservers
+	// If no nameservers were successfully loaded, check for authoritative flag
 	if len(app.Nameservers) == 0 {
+		if app.QueryFlags.UseAuthoritative && len(app.QueryFlags.QNames) > 0 {
+			return app.loadAuthoritativeNameserver(app.QueryFlags.QNames[0])
+		}
 		return app.loadSystemNameservers()
 	}
 
@@ -454,4 +458,54 @@ func (app *App) getDefaultServers() ([]models.Nameserver, int, []string, error) 
 	}
 
 	return servers, ndots, search, nil
+}
+
+// loadAuthoritativeNameserver walks up the domain hierarchy via SOA queries to
+// find the zone's primary nameserver and adds it to app.Nameservers.
+func (app *App) loadAuthoritativeNameserver(domain string) error {
+	systemServers, _, _, err := config.GetDefaultServers()
+	if err != nil || len(systemServers) == 0 {
+		return fmt.Errorf("unable to load system nameservers for SOA lookup: %w", err)
+	}
+	resolver := net.JoinHostPort(systemServers[0], models.DefaultUDPPort)
+
+	c := &dns.Client{Timeout: 5 * time.Second}
+	candidate := dns.Fqdn(domain)
+
+	for {
+		m := new(dns.Msg)
+		m.SetQuestion(candidate, dns.TypeSOA)
+		m.RecursionDesired = true
+
+		r, _, err := c.Exchange(m, resolver)
+		if err == nil {
+			if soa := firstSOA(r); soa != nil {
+				nsHost := strings.TrimSuffix(soa.Ns, ".")
+				ns, err := initNameserver(nsHost)
+				if err != nil {
+					return fmt.Errorf("invalid authoritative nameserver %q: %w", nsHost, err)
+				}
+				app.Logger.Debug("Resolved authoritative nameserver via SOA", "zone", candidate, "ns", nsHost)
+				app.Nameservers = append(app.Nameservers, ns)
+				return nil
+			}
+		}
+
+		// No SOA found — walk up to the parent zone.
+		labels := dns.SplitDomainName(candidate)
+		if len(labels) <= 1 {
+			return fmt.Errorf("no authoritative nameserver found for %q", domain)
+		}
+		candidate = dns.Fqdn(strings.Join(labels[1:], "."))
+	}
+}
+
+// firstSOA returns the first SOA record from the answer or authority section.
+func firstSOA(r *dns.Msg) *dns.SOA {
+	for _, rr := range append(r.Answer, r.Ns...) {
+		if soa, ok := rr.(*dns.SOA); ok {
+			return soa
+		}
+	}
+	return nil
 }

--- a/internal/app/nameservers.go
+++ b/internal/app/nameservers.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -460,8 +461,16 @@ func (app *App) getDefaultServers() ([]models.Nameserver, int, []string, error) 
 	return servers, ndots, search, nil
 }
 
-// loadAuthoritativeNameserver walks up the domain hierarchy via SOA queries to
-// find the zone's primary nameserver and adds it to app.Nameservers.
+// loadAuthoritativeNameserver finds the closest enclosing zone for the domain
+// via SOA queries, then resolves that zone's delegated NS RRset and adds those
+// nameservers to app.Nameservers.
+//
+// SOA is used only to locate the zone cut. The actual query targets come from
+// the zone's NS records, which are the publicly delegated authoritative
+// servers. We deliberately avoid SOA.Ns (the zone primary/MNAME): it is often
+// an internal hostname that does not resolve publicly (e.g. amazon.com's MNAME
+// is dns-external-route53.us-east-1.amazonaws.com), whereas the delegated NS
+// set is what recursive resolvers actually query.
 func (app *App) loadAuthoritativeNameserver(domain string) error {
 	systemServers, _, _, err := config.GetDefaultServers()
 	if err != nil || len(systemServers) == 0 {
@@ -470,8 +479,48 @@ func (app *App) loadAuthoritativeNameserver(domain string) error {
 	resolver := net.JoinHostPort(systemServers[0], models.DefaultUDPPort)
 
 	c := &dns.Client{Timeout: 5 * time.Second}
-	candidate := dns.Fqdn(domain)
 
+	// Step 1: use SOA to identify the closest enclosing zone (the zone cut).
+	zone, err := app.closestZone(c, resolver, dns.Fqdn(domain))
+	if err != nil {
+		return err
+	}
+
+	// Step 2: fetch that zone's delegated NS RRset — the public authoritative servers.
+	nsNames, err := app.zoneNameservers(c, resolver, zone)
+	if err != nil {
+		return err
+	}
+
+	servers := make([]models.Nameserver, 0, len(nsNames))
+	for _, name := range nsNames {
+		ns, err := initNameserver(strings.TrimSuffix(name, "."))
+		if err != nil {
+			app.Logger.Debug("Skipping invalid authoritative nameserver", "ns", name, "error", err)
+			continue
+		}
+		servers = append(servers, ns)
+	}
+	if len(servers) == 0 {
+		return fmt.Errorf("no usable authoritative nameservers found for zone %q", strings.TrimSuffix(zone, "."))
+	}
+
+	app.Logger.Debug("Resolved authoritative nameservers via NS RRset", "zone", zone, "nameservers", servers)
+
+	// Step 3: let the nameserver strategy select the query target(s).
+	servers, err = app.applyNameserverStrategy(servers, "authoritative")
+	if err != nil {
+		return err
+	}
+
+	app.Nameservers = append(app.Nameservers, servers...)
+	return nil
+}
+
+// closestZone walks up the domain hierarchy issuing SOA queries until it finds
+// the closest enclosing zone, returning that zone's apex as an FQDN.
+func (app *App) closestZone(c *dns.Client, resolver, candidate string) (string, error) {
+	domain := candidate
 	for {
 		m := new(dns.Msg)
 		m.SetQuestion(candidate, dns.TypeSOA)
@@ -480,24 +529,46 @@ func (app *App) loadAuthoritativeNameserver(domain string) error {
 		r, _, err := c.Exchange(m, resolver)
 		if err == nil {
 			if soa := firstSOA(r); soa != nil {
-				nsHost := strings.TrimSuffix(soa.Ns, ".")
-				ns, err := initNameserver(nsHost)
-				if err != nil {
-					return fmt.Errorf("invalid authoritative nameserver %q: %w", nsHost, err)
-				}
-				app.Logger.Debug("Resolved authoritative nameserver via SOA", "zone", candidate, "ns", nsHost)
-				app.Nameservers = append(app.Nameservers, ns)
-				return nil
+				// The SOA owner name is the zone apex regardless of the label
+				// we queried: a recursive resolver returns the enclosing zone's
+				// SOA in the authority section for sub-zone names.
+				return soa.Hdr.Name, nil
 			}
 		}
 
 		// No SOA found — walk up to the parent zone.
 		labels := dns.SplitDomainName(candidate)
 		if len(labels) <= 1 {
-			return fmt.Errorf("no authoritative nameserver found for %q", domain)
+			return "", fmt.Errorf("no authoritative zone found for %q", strings.TrimSuffix(domain, "."))
 		}
 		candidate = dns.Fqdn(strings.Join(labels[1:], "."))
 	}
+}
+
+// zoneNameservers queries the NS RRset for the given zone and returns the
+// delegated nameserver hostnames, sorted for deterministic selection.
+func (app *App) zoneNameservers(c *dns.Client, resolver, zone string) ([]string, error) {
+	m := new(dns.Msg)
+	m.SetQuestion(zone, dns.TypeNS)
+	m.RecursionDesired = true
+
+	r, _, err := c.Exchange(m, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query NS records for zone %q: %w", strings.TrimSuffix(zone, "."), err)
+	}
+
+	var names []string
+	for _, rr := range append(r.Answer, r.Ns...) {
+		if ns, ok := rr.(*dns.NS); ok {
+			names = append(names, ns.Ns)
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no NS records found for zone %q", strings.TrimSuffix(zone, "."))
+	}
+	sort.Strings(names)
+
+	return names, nil
 }
 
 // firstSOA returns the first SOA record from the answer or authority section.

--- a/internal/app/nameservers_test.go
+++ b/internal/app/nameservers_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/mr-karan/doggo/pkg/models"
@@ -91,6 +92,37 @@ func TestLoadAuthoritativeNameserver(t *testing.T) {
 		t.Fatal("expected at least one authoritative nameserver, got none")
 	}
 	t.Logf("resolved authoritative NS for github.com: %v", app.Nameservers[0].Address)
+}
+
+// TestLoadAuthoritativeNameserverUsesDelegatedNS verifies the resolver targets
+// come from the zone's delegated NS RRset, not the SOA primary (MNAME). amazon.com
+// is the canonical case: its MNAME (dns-external-route53.us-east-1.amazonaws.com)
+// is not publicly queryable, while its delegated NS set lives under awsdns-*.
+func TestLoadAuthoritativeNameserverUsesDelegatedNS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test requiring network")
+	}
+	app := newTestApp()
+	app.QueryFlags.UseAuthoritative = true
+	app.QueryFlags.QNames = []string{"amazon.com"}
+
+	if err := app.LoadNameservers(); err != nil {
+		t.Fatalf("LoadNameservers() error = %v", err)
+	}
+
+	if len(app.Nameservers) == 0 {
+		t.Fatal("expected at least one authoritative nameserver, got none")
+	}
+
+	for _, ns := range app.Nameservers {
+		if strings.Contains(ns.Address, "dns-external-route53") {
+			t.Fatalf("selected SOA primary (MNAME) instead of delegated NS: %v", ns.Address)
+		}
+		if !strings.Contains(ns.Address, "awsdns") {
+			t.Errorf("expected a delegated awsdns nameserver, got %v", ns.Address)
+		}
+	}
+	t.Logf("resolved authoritative NS for amazon.com: %v", app.Nameservers)
 }
 
 func assertNameservers(t *testing.T, got, want []models.Nameserver) {

--- a/internal/app/nameservers_test.go
+++ b/internal/app/nameservers_test.go
@@ -59,6 +59,40 @@ func newTestApp() App {
 	}
 }
 
+func TestLoadNameserversExplicitNameserverTakesPrecedenceOverAuthoritative(t *testing.T) {
+	app := newTestApp()
+	app.QueryFlags.Nameservers = []string{"1.1.1.1"}
+	app.QueryFlags.UseAuthoritative = true
+	app.QueryFlags.QNames = []string{"github.com"}
+
+	if err := app.LoadNameservers(); err != nil {
+		t.Fatalf("LoadNameservers() error = %v", err)
+	}
+
+	want := []models.Nameserver{
+		{Address: "1.1.1.1:53", Type: models.UDPResolver},
+	}
+	assertNameservers(t, app.Nameservers, want)
+}
+
+func TestLoadAuthoritativeNameserver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test requiring network")
+	}
+	app := newTestApp()
+	app.QueryFlags.UseAuthoritative = true
+	app.QueryFlags.QNames = []string{"github.com"}
+
+	if err := app.LoadNameservers(); err != nil {
+		t.Fatalf("LoadNameservers() error = %v", err)
+	}
+
+	if len(app.Nameservers) == 0 {
+		t.Fatal("expected at least one authoritative nameserver, got none")
+	}
+	t.Logf("resolved authoritative NS for github.com: %v", app.Nameservers[0].Address)
+}
+
 func assertNameservers(t *testing.T, got, want []models.Nameserver) {
 	t.Helper()
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -45,6 +45,7 @@ type QueryFlags struct {
 	InsecureSkipVerify bool          `koanf:"skip-hostname-verification" skip-hostname-verification:"-"`
 	TLSHostname        string        `koanf:"tls-hostname" tls-hostname:"-"`
 	QueryAny           bool          `koanf:"any" json:"any"`
+	UseAuthoritative   bool          `koanf:"authoritative" json:"authoritative"`
 
 	// DNS Query Flags
 	AA bool `koanf:"aa" json:"aa"` // Authoritative Answer


### PR DESCRIPTION
## What

Adds a `-A` / `--authoritative` flag that automatically finds and queries the authoritative nameserver for the queried domain, rather than routing through the system resolver or a manually-specified server.

```
doggo mrkaran.dev A --authoritative
doggo -A mrkaran.dev
```

## Why it's useful

Recursive resolvers return cached answers. Querying the authoritative NS directly is useful when debugging DNS propagation, verifying what a zone is actually serving, or investigating split-horizon configurations.

## How it works

When `--authoritative` is set and no explicit `--nameserver` is given, doggo walks the SOA hierarchy:

1. Queries the system resolver for an SOA record for the domain.
2. If none is found at that label, strips the leftmost label and repeats (walking toward the root).
3. Once an SOA is found, extracts the primary NS (`SOA.Ns`) and uses it as the nameserver for all questions.

Explicit `--nameserver` takes precedence — `--authoritative` is silently ignored when a nameserver is already specified.

## Changes

- `pkg/models/models.go` — add `UseAuthoritative bool` to `QueryFlags`
- `internal/app/nameservers.go` — `loadAuthoritativeNameserver()` + `firstSOA()` helper; hook in `LoadNameservers()`
- `cmd/doggo/cli.go` — register `-A` / `--authoritative` flag
- `cmd/doggo/help.go` — add entry to query-options help section
- `internal/app/nameservers_test.go` — unit tests for flag-precedence and SOA walk (network test gated behind `-short`)