### PR TITLE
fix(nameservers): let --strategy internal find VPN/Tailscale resolvers on macOS

### DIFF
--- a/internal/app/nameservers.go
+++ b/internal/app/nameservers.go
@@ -273,15 +273,16 @@ func isIPv6(ipStr string) bool {
 	return ip.To4() == nil
 }
 
-// isPrivateIP checks if an IP address is in RFC 1918 private address space (IPv4)
-// or RFC 4193 Unique Local Address space (IPv6)
+// isPrivateIP reports whether an IP address belongs to a private/internal
+// range: RFC 1918 (IPv4), RFC 6598 Carrier-Grade NAT (IPv4, used by Tailscale's
+// 100.100.100.100 MagicDNS resolver), or RFC 4193 Unique Local Addresses (IPv6).
 func isPrivateIP(ipStr string) bool {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return false
 	}
 
-	// IPv4 RFC 1918 ranges
+	// IPv4 ranges
 	if ipv4 := ip.To4(); ipv4 != nil {
 		// 10.0.0.0/8
 		if ipv4[0] == 10 {
@@ -293,6 +294,10 @@ func isPrivateIP(ipStr string) bool {
 		}
 		// 192.168.0.0/16
 		if ipv4[0] == 192 && ipv4[1] == 168 {
+			return true
+		}
+		// 100.64.0.0/10 (RFC 6598 CGNAT, e.g. Tailscale)
+		if ipv4[0] == 100 && ipv4[1] >= 64 && ipv4[1] <= 127 {
 			return true
 		}
 		return false
@@ -411,8 +416,16 @@ func nameserverHost(ns models.Nameserver) string {
 }
 
 func (app *App) getDefaultServers() ([]models.Nameserver, int, []string, error) {
-	// Load nameservers from `/etc/resolv.conf`.
-	dnsServers, ndots, search, err := config.GetDefaultServers()
+	// Load nameservers from the system resolver configuration. The "internal"
+	// strategy needs to see Supplemental/domain-scoped resolvers (e.g. a VPN or
+	// Tailscale split-DNS resolver), which GetDefaultServers hides, so it sources
+	// the broader GetAllServers list instead.
+	loadServers := config.GetDefaultServers
+	if app.QueryFlags.Strategy == "internal" {
+		loadServers = config.GetAllServers
+	}
+
+	dnsServers, ndots, search, err := loadServers()
 	if err != nil {
 		return nil, 0, nil, err
 	}

--- a/internal/app/nameservers_test.go
+++ b/internal/app/nameservers_test.go
@@ -50,6 +50,41 @@ func TestLoadNameserversReturnsErrorWhenExplicitInternalStrategyHasNoPrivateName
 	}
 }
 
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		// RFC 1918
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"172.31.255.255", true},
+		{"172.32.0.1", false},
+		{"192.168.1.1", true},
+		// RFC 6598 CGNAT (e.g. Tailscale MagicDNS)
+		{"100.100.100.100", true},
+		{"100.64.0.0", true},
+		{"100.127.255.255", true},
+		{"100.63.255.255", false}, // just below the range
+		{"100.128.0.0", false},    // just above the range
+		// Public
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		// IPv6 ULA (RFC 4193): only the locally-assigned fd00::/8 half is matched
+		{"fd7a:115c:a1e0::53", true},
+		{"fc00::1", false}, // reserved/unused ULA half, not matched
+		{"2606:4700:4700::1111", false},
+		// Invalid
+		{"not-an-ip", false},
+	}
+
+	for _, tc := range cases {
+		if got := isPrivateIP(tc.ip); got != tc.want {
+			t.Errorf("isPrivateIP(%q) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}
+
 func newTestApp() App {
 	return App{
 		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/pkg/config/config_darwin.go
+++ b/pkg/config/config_darwin.go
@@ -27,9 +27,29 @@ type scutilResolver struct {
 
 // GetDefaultServers retrieves DNS configuration from macOS SystemConfiguration
 // by parsing the output of 'scutil --dns'. Falls back to /etc/resolv.conf on failure.
+//
+// Only general-purpose resolvers are returned: Supplemental and domain-scoped
+// resolvers are excluded because they apply to specific domains, not arbitrary
+// queries. See GetAllServers for the strategy-aware variant.
 func GetDefaultServers() ([]string, int, []string, error) {
+	return getSystemServers(false)
+}
+
+// GetAllServers is like GetDefaultServers but also includes Supplemental and
+// domain-scoped resolvers (e.g. the resolvers a VPN or Tailscale installs for
+// split-DNS). It exists so the "internal" nameserver strategy can discover
+// private corporate/VPN resolvers that GetDefaultServers intentionally hides.
+// mDNS resolvers (.local and reverse-DNS) are still excluded.
+func GetAllServers() ([]string, int, []string, error) {
+	return getSystemServers(true)
+}
+
+// getSystemServers tries scutil first and falls back to /etc/resolv.conf.
+// includeSupplemental controls whether Supplemental/domain-scoped resolvers
+// are kept (see GetAllServers).
+func getSystemServers(includeSupplemental bool) ([]string, int, []string, error) {
 	// Try scutil first
-	resolvers, ndots, search, err := getResolversFromScutil()
+	resolvers, ndots, search, err := getResolversFromScutil(includeSupplemental)
 	if err != nil {
 		// Fallback to /etc/resolv.conf
 		return fallbackToResolvConf()
@@ -39,7 +59,7 @@ func GetDefaultServers() ([]string, int, []string, error) {
 }
 
 // getResolversFromScutil executes scutil --dns and parses the output
-func getResolversFromScutil() ([]string, int, []string, error) {
+func getResolversFromScutil(includeSupplemental bool) ([]string, int, []string, error) {
 	// Execute scutil --dns
 	cmd := exec.Command("scutil", "--dns")
 	var stdout bytes.Buffer
@@ -60,16 +80,7 @@ func getResolversFromScutil() ([]string, int, []string, error) {
 		return nil, 0, nil, fmt.Errorf("failed to parse scutil output: %w", err)
 	}
 
-	// Filter out resolvers that shouldn't be used for general queries:
-	// - mDNS resolvers (for .local domains)
-	// - Supplemental resolvers (flagged as domain-specific)
-	// - Domain-specific resolvers (have explicit domain field)
-	validResolvers := make([]scutilResolver, 0)
-	for _, r := range resolvers {
-		if !isMDNS(r) && !isSupplemental(r) && !isDomainSpecific(r) && len(r.nameservers) > 0 {
-			validResolvers = append(validResolvers, r)
-		}
-	}
+	validResolvers := filterResolvers(resolvers, includeSupplemental)
 
 	if len(validResolvers) == 0 {
 		return nil, 0, nil, fmt.Errorf("no valid resolvers found")
@@ -186,6 +197,28 @@ func parseScutilOutput(output string) ([]scutilResolver, error) {
 	}
 
 	return resolvers, nil
+}
+
+// filterResolvers selects resolvers usable for outbound DNS queries.
+//
+// mDNS resolvers (.local and reverse-DNS) and resolvers with no nameservers are
+// always excluded. By default Supplemental and domain-scoped resolvers are also
+// excluded, since they apply only to specific domains rather than general
+// queries. When includeSupplemental is set they are kept, so the "internal"
+// strategy can discover private VPN/Tailscale resolvers that would otherwise be
+// hidden.
+func filterResolvers(resolvers []scutilResolver, includeSupplemental bool) []scutilResolver {
+	validResolvers := make([]scutilResolver, 0)
+	for _, r := range resolvers {
+		if isMDNS(r) || len(r.nameservers) == 0 {
+			continue
+		}
+		if !includeSupplemental && (isSupplemental(r) || isDomainSpecific(r)) {
+			continue
+		}
+		validResolvers = append(validResolvers, r)
+	}
+	return validResolvers
 }
 
 // isMDNS checks if a resolver is for mDNS (.local)

--- a/pkg/config/config_darwin_test.go
+++ b/pkg/config/config_darwin_test.go
@@ -142,6 +142,73 @@ func TestFilterScutilResolvers(t *testing.T) {
 	}
 }
 
+// TestParseScutilOutputIncludeSupplemental mirrors a Tailscale split-DNS layout
+// (the same shape reported on real machines): the private 100.100.100.100 /
+// fd7a:... resolvers are flagged Supplemental, while the only general resolver
+// is public 8.8.8.8. With includeSupplemental, the Supplemental resolvers must
+// survive (so the "internal" strategy can find them) while mDNS stays excluded.
+func TestParseScutilOutputIncludeSupplemental(t *testing.T) {
+	const tailscaleScutil = `
+DNS configuration
+
+resolver #1
+  search domain[0] : tailedcc0.ts.net
+  search domain[1] : home
+  nameserver[0] : 100.100.100.100
+  nameserver[1] : fd7a:115c:a1e0::53
+  if_index : 19 (utun4)
+  flags    : Supplemental, Request A records, Request AAAA records
+  reach    : 0x00000003 (Reachable,Transient Connection)
+  order    : 101200
+
+resolver #2
+  nameserver[0] : 8.8.8.8
+  flags    : Request A records, Request AAAA records
+  reach    : 0x00000002 (Reachable)
+  order    : 200000
+
+resolver #3
+  domain   : tailedcc0.ts.net.
+  nameserver[0] : 100.100.100.100
+  nameserver[1] : fd7a:115c:a1e0::53
+  if_index : 19 (utun4)
+  flags    : Supplemental, Request A records, Request AAAA records
+  reach    : 0x00000003 (Reachable,Transient Connection)
+  order    : 101201
+
+resolver #4
+  domain   : local
+  options  : mdns
+  flags    : Request A records
+  reach    : 0x00000000 (Not Reachable)
+  order    : 300000
+
+DNS configuration (for scoped queries)
+`
+	resolvers, err := parseScutilOutput(tailscaleScutil)
+	if err != nil {
+		t.Fatalf("parseScutilOutput error: %v", err)
+	}
+
+	// Default (general queries only): just the public resolver #2 survives.
+	general := filterResolvers(resolvers, false)
+	if len(general) != 1 || general[0].number != 2 {
+		t.Fatalf("includeSupplemental=false: expected only resolver #2, got %+v", general)
+	}
+
+	// Internal strategy source: Supplemental and domain-scoped resolvers are
+	// kept (#1, #2, #3); only the mDNS resolver #4 is dropped.
+	all := filterResolvers(resolvers, true)
+	gotNumbers := make([]int, 0, len(all))
+	for _, r := range all {
+		gotNumbers = append(gotNumbers, r.number)
+	}
+	wantNumbers := []int{1, 2, 3}
+	if !reflect.DeepEqual(gotNumbers, wantNumbers) {
+		t.Fatalf("includeSupplemental=true: expected resolvers %v, got %v", wantNumbers, gotNumbers)
+	}
+}
+
 func TestFilterDomainSpecificWithoutSupplementalFlag(t *testing.T) {
 	input := `
 DNS configuration

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -28,3 +28,10 @@ func GetDefaultServers() ([]string, int, []string, error) {
 	}
 	return servers, cfg.Ndots, cfg.Search, nil
 }
+
+// GetAllServers returns the same servers as GetDefaultServers. On UNIX,
+// resolv.conf has no concept of Supplemental/scoped resolvers, so every
+// configured nameserver is already visible to every strategy.
+func GetAllServers() ([]string, int, []string, error) {
+	return GetDefaultServers()
+}

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -118,3 +118,10 @@ func GetDefaultServers() ([]string, int, []string, error) {
 	servers, err := getDefaultDNSServers()
 	return servers, 0, nil, err
 }
+
+// GetAllServers returns the same servers as GetDefaultServers. Windows does not
+// expose Supplemental/scoped resolvers the way macOS does, so every configured
+// nameserver is already visible to every strategy.
+func GetAllServers() ([]string, int, []string, error) {
+	return GetDefaultServers()
+}


### PR DESCRIPTION
## Problem

`doggo <name> --strategy internal` fails on macOS with:

```
error fetching system default nameserver: no internal (private IP) nameservers found in system configuration
```

…even when the machine clearly has a private resolver. This reproduces with **Tailscale** (and split-DNS VPNs generally), where `scutil --dns` looks like:

```
resolver #1
  nameserver[0] : 100.100.100.100
  nameserver[1] : fd7a:115c:a1e0::53
  flags    : Supplemental, ...
resolver #2
  nameserver[0] : 8.8.8.8
  flags    : Request A records, Request AAAA records
resolver #3
  domain   : tailedcc0.ts.net.
  nameserver[0] : 100.100.100.100
  flags    : Supplemental, ...
```

Two causes compound:

1. **The scutil parser discards every `Supplemental`/domain-scoped resolver**, so the only survivor is the public general-query resolver (`8.8.8.8`). The private Tailscale resolvers (#1, #3) — exactly what `internal` should select — are dropped before the strategy runs.
2. **`isPrivateIP` doesn't recognize CGNAT**, so even if `100.100.100.100` survived, it wouldn't count as internal (Tailscale uses RFC 6598 `100.64.0.0/10`).

## Fix

- Add `config.GetAllServers()` (all platforms). On macOS it keeps `Supplemental`/domain-scoped resolvers (mDNS still excluded); on UNIX/Windows it aliases `GetDefaultServers()` since those platforms have no Supplemental concept.
- `getDefaultServers()` sources from `GetAllServers()` **only when `--strategy internal`**. All other strategies use the existing general list.
- Add RFC 6598 CGNAT (`100.64.0.0/10`) to `isPrivateIP`.
- Extract `filterResolvers(resolvers, includeSupplemental)` so the filter is unit-testable.

### Why strategy-scoped, not global

doggo queries **all** loaded nameservers concurrently, and the default list intentionally excludes Supplemental resolvers (matching what macOS uses for general queries). Folding the Tailscale resolver into the default path would make plain `doggo` query both `8.8.8.8` and `100.100.100.100` — a regression. So only `--strategy internal` sees the broader list; default behavior is unchanged.

## Verification

Live, on the reporting machine:

```
strategy=internal  before=[100.100.100.100:53, [fd7a:115c:a1e0::53]:53, 8.8.8.8:53]
                   after =[100.100.100.100:53, [fd7a:115c:a1e0::53]:53]   # 8.8.8.8 dropped
default strategy   -> still loads [8.8.8.8] only (unchanged)
```

## Tests

- `TestIsPrivateIP` — CGNAT boundaries (`100.64`–`100.127`), RFC 1918, IPv6 ULA, public, invalid.
- `TestParseScutilOutputIncludeSupplemental` — the exact Tailscale scutil layout, asserting both filter modes (`false` → only the public resolver; `true` → Supplemental/domain-scoped kept, mDNS dropped).

`go test ./...` passes; `go vet` clean.
